### PR TITLE
BF: remove unicode_literals from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
-from __future__ import unicode_literals
 
 from setuptools import setup
 from distutils.version import LooseVersion


### PR DESCRIPTION
setu.py is currently failing for me under win and OSX (and so installing with pip also fails):
```
Traceback (most recent call last):
  File "setup.py", line 108, in <module>
    'Topic :: Scientific/Engineering'
  File "C:\Python27\lib\distutils\core.py", line 151, in setup
    dist.run_commands()
  File "C:\Python27\lib\distutils\dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "C:\Python27\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "C:\Python27\lib\distutils\command\build.py", line 127, in run
    self.run_command(cmd_name)
  File "C:\Python27\lib\distutils\cmd.py", line 326, in run_command
    self.distribution.run_command(command)
  File "C:\Python27\lib\distutils\dist.py", line 972, in run_command
    cmd_obj.run()
  File "C:\Python27\lib\site-packages\setuptools\command\build_py.py", line 50, in run
    self.build_packages()
  File "C:\Python27\lib\distutils\command\build_py.py", line 373, in build_packages
    self.build_module(module, module_file, package)
  File "C:\Python27\lib\site-packages\setuptools\command\build_py.py", line 70, in build_module
    package)
  File "C:\Python27\lib\distutils\command\build_py.py", line 334, in build_module
    "'package' must be a string (dot-separated), list, or tuple")
TypeError: 'package' must be a string (dot-separated), list, or tuple
```

I guess that setuptools is doing a test for `type(package)==str` which returns False in your case because of silent conversion to a unicode instead.

Alternative workaround is to do:
    from setuptools import setup, find_packages
and then use find_packages() instead of your list of string/unicodes