### PR TITLE
correction in stats.confidence

### DIFF
--- a/psychopy_ext/stats.py
+++ b/psychopy_ext/stats.py
@@ -209,7 +209,7 @@ def confidence(agg, kind='sem', within=None, alpha=.05, nsamples=None,
 
             levels = []
             for dim in within:
-                tmp = [r for r in agg.columns.names if not r.startswith(dim + '.')]
+                tmp = [r for r in agg.columns.values if not r.startswith(dim + '.')]
                 levels += tmp
             if len(levels) > 0:
                 #raise Exception('Could not find levels that start with any of the following: %s' % within)


### PR DESCRIPTION
I encountered a few changes in the stats-API while trying to follow the [GestaltRevision Tutorial](http://nbviewer.jupyter.org/github/gestaltrevision/python_for_visres/blob/master/Part5/Part5_psychopy_ext.ipynb#Aggregating-data). I could make a lot of it work, except stats.confidence.

I kept getting 'NoneType has no attribute startswith' for agg.columns.names (which somehow needs to be a single string if I understand correctly; however, I cannot find any documentation on this) . The actual column names seem to be stored in columns.values.

There are a lot of firsts for me here (first time working with psychopy, psychopy_ext and pandas, first pull request), I hope this isn't completely stupid.

[Edit: corrected Markdown Syntax of link, typo]