### PR TITLE
workaround for KeyError on in-/nonvalid keypress

### DIFF
--- a/psychopy_ext/exp.py
+++ b/psychopy_ext/exp.py
@@ -1192,7 +1192,10 @@ class Task(TrialHandler):
             if hasattr(self, 'respmap'):
                 subj_resp = this_resp[2]
             else:
-                subj_resp = self.computer.valid_responses[this_resp[0]]
+                try:
+                    subj_resp = self.computer.valid_responses[this_resp[0]]
+                except KeyError:
+                    subj_resp=''
             self.this_trial['subj_resp'] = subj_resp
 
             try:


### PR DESCRIPTION
I got a KeyError whenever a key was pressed (e.g. during idlevents) that is not in computer.valid_responses. Working around this with method overriding seemed even more messy, so I added this try-except block to `Experiment.post_trial()`.

I hope I didn't miss something obvious here.
